### PR TITLE
GenerateDocumentationFile flag in csproj

### DIFF
--- a/SharpFontCore/SharpFontCore.csproj
+++ b/SharpFontCore/SharpFontCore.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Version>0.1.1</Version>
     <Authors>Mike Popoloski, SpacialCircumstances</Authors>
     <Company />


### PR DESCRIPTION
This PR adds GenerateDocumentationFile flag to csproj in order to allow generate xml documentation file to have intellisense on library functions included in the nuget package.